### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -8,6 +8,9 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/midas-apps/contracts/security/code-scanning/4](https://github.com/midas-apps/contracts/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the actions performed in the workflow (e.g., installing dependencies, running tests, and formatting code), the minimal required permission is `contents: read`. This ensures that the workflow can read repository contents without granting unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
