### PR TITLE
 Fix: Enforce authenticated LayerZero sender attribution and native refund propagation

### DIFF
--- a/contracts/misc/adapters/PythChainlinkAdapter.sol
+++ b/contracts/misc/adapters/PythChainlinkAdapter.sol
@@ -47,8 +47,10 @@ contract PythChainlinkAdapter is ChainlinkAdapterBase {
         uint256 fee = pyth.getUpdateFee(priceUpdateData);
         pyth.updatePriceFeeds{value: fee}(priceUpdateData);
 
-        // refund remaining eth
-        payable(msg.sender).call{value: address(this).balance}("");
+        // Refund remaining ETH and revert if the recipient rejects the transfer.
+        (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
+        require(success, "PythChainlinkAdapter: refund failed");
+
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/contracts/misc/layerzero/MidasLzVaultComposerSync.sol
+++ b/contracts/misc/layerzero/MidasLzVaultComposerSync.sol
@@ -197,8 +197,7 @@ contract MidasLzVaultComposerSync is
                 }
             }
 
-            // solhint-disable-next-line avoid-tx-origin
-            _refund(_composeSender, _message, amount, tx.origin);
+            _refund(_composeSender, _message, amount, composeFrom.bytes32ToAddress());
             emit Refunded(_guid);
         }
     }
@@ -243,8 +242,7 @@ contract MidasLzVaultComposerSync is
                 _amount,
                 extraOptions,
                 sendParam,
-                // solhint-disable-next-line avoid-tx-origin
-                tx.origin
+                _composeFrom.bytes32ToAddress()
             );
         } else {
             _redeemAndSend(
@@ -252,8 +250,7 @@ contract MidasLzVaultComposerSync is
                 _amount,
                 extraOptions,
                 sendParam,
-                // solhint-disable-next-line avoid-tx-origin
-                tx.origin
+                _composeFrom.bytes32ToAddress()
             );
         }
     }


### PR DESCRIPTION
### Description
This PR addresses critical cross-chain authorization and error-handling vulnerabilities within the EVM contract adapters[cite: 46]. Previously, the `MidasLzVaultComposerSync` contract used `tx.origin` for vault routing and refunds, which could be manipulated by intermediary contracts. Additionally, the `PythChainlinkAdapter` discarded native-asset refund failures, potentially trapping funds.

### Key Changes
* **LayerZero Sender Attribution (`contracts/contracts/misc/layerzero/MidasLzVaultComposerSync.sol`):** Replaced all instances of `tx.origin` with the authenticated `composeFrom` address derived from the LayerZero compose message[cite: 46, 51]. Deposit, redemption, and refund paths now strictly attribute value to the authenticated cross-chain sender (`composeFrom.bytes32ToAddress()`)[cite: 46, 51].
* **Refund Failure Propagation (`contracts/contracts/misc/adapters/PythChainlinkAdapter.sol`):** Updated the `updateFeeds` function to explicitly require success when refunding remaining ETH to the caller[cite: 46, 50]. If the recipient rejects the transfer, the transaction now correctly reverts with `PythChainlinkAdapter: refund failed`, preventing trapped funds in the adapter[cite: 50].

### Validation
* A PowerShell `Select-String` regression guard confirms zero occurrences of `tx.origin` remain in the modified composer[cite: 46].
* Native Solidity compilation was skipped because Corepack requested an unauthorized network download[cite: 46]. Reviewers must run `yarn compile` in the deployment environment.